### PR TITLE
Added null-check to name mapper.

### DIFF
--- a/src/main/scala/org/clapper/classutil/asm/ClassFinderImpl.scala
+++ b/src/main/scala/org/clapper/classutil/asm/ClassFinderImpl.scala
@@ -194,7 +194,10 @@ extends EmptyVisitor with ASMBitmapMapper
         null
     }
 
-    private def mapClassName(name: String): String = name.replaceAll("/", ".")
+    private def mapClassName(name: String): String = {
+      if(name == null) ""
+      else name.replaceAll("/", ".")
+   }
 }
 
 private[classutil] object ClassFile


### PR DESCRIPTION
Hi Brian,

I'm investigating ClassUtil for use in an indexer component for Ensime. I ran into one little bug so far - a null pointer exception in the ClassInfo creation logic. The included commit fixes the issue. I just wanted to bring this to your attention, and expect you may have a more elegant solution.

BTW: Thanks for the great tool. So far, seems to fit my needs perfectly.

Thanks,
Aemon Cannon
