### PR TITLE
use newer sbt-bintray version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# Travis CI configuration file. Generated from build.sbt on Sat May 21 14:15:26 EDT 2016
-
 sudo: false
 
 # These directories are cached to S3 at the end of the build.
@@ -22,6 +20,6 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.10.6
-  - 2.11.8
-  - 2.12.4
+  - 2.10.7
+  - 2.11.12
+  - 2.12.6

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ https://opensource.org/licenses/BSD-3-Clause
 
 ---
 
-Copyright &copy; 2010-2016, Brian M. Clapper.
+Copyright &copy; 2010-2018, Brian M. Clapper.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ClassUtil is fast for several reasons:
 Please see the full documentation on the [library's home page][] for all the
 gory details, including caveats.
 
-ClassUtil is copyright &copy; 2010-2017 [Brian M. Clapper][] and is released
+ClassUtil is copyright &copy; 2010-2018 [Brian M. Clapper][] and is released
 under a new BSD license.
 
 [library's home page]: http://software.clapper.org/classutil

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ homepage := Some(url("http://software.clapper.org/classutil/"))
 
 description := "A library for fast runtime class-querying, and more"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.6")
 
 // ---------------------------------------------------------------------------
 // Additional compiler options and plugins
@@ -32,7 +32,7 @@ autoCompilerPlugins := true
 // ---------------------------------------------------------------------------
 // ScalaTest dependendency
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
 // ---------------------------------------------------------------------------
 // Other dependendencies

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/src/main/scala/org/clapper/classutil/ClassFinder.scala
+++ b/src/main/scala/org/clapper/classutil/ClassFinder.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/main/scala/org/clapper/classutil/ClassUtil.scala
+++ b/src/main/scala/org/clapper/classutil/ClassUtil.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/main/scala/org/clapper/classutil/MapToBean.scala
+++ b/src/main/scala/org/clapper/classutil/MapToBean.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/main/scala/org/clapper/classutil/asm/ClassFinderImpl.scala
+++ b/src/main/scala/org/clapper/classutil/asm/ClassFinderImpl.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/main/scala/org/clapper/classutil/asm/InterfaceMaker.scala
+++ b/src/main/scala/org/clapper/classutil/asm/InterfaceMaker.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/main/scala/org/clapper/classutil/package.scala
+++ b/src/main/scala/org/clapper/classutil/package.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without

--- a/src/test/scala/org/clapper/classutil/ClassUtilSpec.scala
+++ b/src/test/scala/org/clapper/classutil/ClassUtilSpec.scala
@@ -3,7 +3,7 @@
   This software is released under a BSD license, adapted from
   http://opensource.org/licenses/bsd-license.php
 
-  Copyright (c) 2010, Brian M. Clapper
+  Copyright (c) 2010-2018, Brian M. Clapper
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
the bintray upgrade is required in order for classutil to be in the
Scala community build

the other commits are just gravy.