### PR TITLE
Make test suite work on non-release versions of Scala

### DIFF
--- a/src/test/scala/org/clapper/classutil/ClassFinderSpec.scala
+++ b/src/test/scala/org/clapper/classutil/ClassFinderSpec.scala
@@ -66,7 +66,7 @@ class ClassFinderSpec extends BaseSpec {
 
   private val (runtimeClassFiles, runtimeClassFinder) = {
     import scala.util.Properties
-    val version = Properties.releaseVersion.get
+    val version = Properties.releaseVersion.orElse(Properties.developmentVersion).get
     val shortVersion = version.split("""\.""").take(2).mkString(".")
 
     val targetDirectory: Option[File] = Array(


### PR DESCRIPTION
We noticed `ClassFinderTest` failing when running it as part of the Scala community build: https://github.com/scala/scala/pull/7203#issuecomment-432470742