### PR TITLE
bump sbt-coursier to latest stable version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 


### PR DESCRIPTION
this makes classutil buildable on JDK 11.  this is useful in the
context of the Scala community build, to help us test Scala
on JDK 11.

I also threw in an sbt version bump, since it's the sbt version
the community build is using.

both changes are also just generally desirable afaik.